### PR TITLE
Show stream of tweets

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   },
   "dependencies": {
     "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react-dom": "^15.3.2",
+    "react-tweet": "^1.0.22",
+    "socket.io-client": "^1.5.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import logo from './logo.svg';
 import './App.css';
+import TwitterStreamContainer from './containers/TwitterStream';
+import TweetsWall from './components/TweetsWall';
 
 class App extends Component {
   render() {
@@ -10,9 +12,9 @@ class App extends Component {
           <img src={logo} className="App-logo" alt="logo" />
           <h2>Welcome to React</h2>
         </div>
-        <p className="App-intro">
-          To get started, edit <code>src/App.js</code> and save to reload.
-        </p>
+        <TwitterStreamContainer>
+          <TweetsWall/>
+        </TwitterStreamContainer>
       </div>
     );
   }

--- a/src/components/TweetsWall.js
+++ b/src/components/TweetsWall.js
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react';
+import Tweet from 'react-tweet'
+
+export default class TweetsWall extends Component {
+  static propTypes = {
+    tweets: PropTypes.array.isRequired
+  }
+
+  static defaultProps = {
+    tweets: []
+  }
+
+  get tweets() {
+    return this.props.tweets.map(tweet => {
+      return <Tweet key={tweet.id} className="TweetsWall-tweet" data={tweet}/>;
+    });
+  }
+
+  render() {
+    return <div className="TweetsWall">
+      {this.tweets}
+    </div>;
+  }
+}

--- a/src/containers/TwitterStream.jsx
+++ b/src/containers/TwitterStream.jsx
@@ -1,0 +1,48 @@
+import io from 'socket.io-client';
+import React, { Component, PropTypes, Children, cloneElement } from 'react';
+
+export default class TwitterStream extends Component {
+  static propTypes = {
+    track: PropTypes.array,
+    children: PropTypes.node
+  }
+
+  static defaultProps = {
+    track: ['rubyconfpt']
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = { track: props.track, tweets: [] };
+  }
+
+  componentDidMount() {
+    this.socket = io('localhost:4000');
+
+    this.socket.on('tweet', this.onTweet);
+  }
+
+  componentWillUnmount() {
+    this.socket.destroy();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.track)
+      this.setState({ track: nextProps.track });
+  }
+
+  onTweet = tweet => this.setState({ tweets: [tweet, ...this.state.tweets] });
+
+  get children() {
+    const { tweets } = this.state;
+    const { children } = this.props;
+
+    return Children.map(children, child => cloneElement(child, { tweets }));
+  }
+
+  render() {
+    return <div className="TwitterStreamContainer">
+      {this.children}
+    </div>;
+  }
+}


### PR DESCRIPTION
Why:
- We need a way to render a stream of tweets

This change addresses the need by:
- Adding `socket.io` to establish a connection to our tweet server;
- Adding `TwitterStream` container, that will subscribe to our `stream` and pass
  the tweets down as props;
- Adding `TweetsWall` component, that will receive the tweets as props and render
  them using an external `Tweet` component.
